### PR TITLE
Fix to avoid PHP-FPM's bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,10 +131,12 @@ function cli(process, beforeMinifyCallback) {
   }
 
   // If no sensible data passed in just print help and exit
-  fromStdin = !process.env.__DIRECT__ && !process.stdin.isTTY;
-  if (!fromStdin && commands.args.length === 0) {
-    commands.outputHelp();
-    return 0;
+  if (commands.args.length === 0) {
+    fromStdin = !process.env.__DIRECT__ && !process.stdin.isTTY;
+    if (!fromStdin) {
+      commands.outputHelp();
+      return 0;
+    }
   }
 
   // Now coerce commands into CleanCSS configuration...


### PR DESCRIPTION
PHP-FPM has a bug with STDIN: https://bugs.php.net/bug.php?id=73342

Running `clean-css-cli` in a PHP's `exec` will hit the bug, and PHP-FPM master's process will peak at 100% CPU usage.

Ignoring the `stdin` test if there's no argument can avoid the bug.