### PR TITLE
Adds support for the --input-source-map flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ clean-css-cli 4.1 introduces the following changes / features:
 --skip-rebase                  Disable URLs rebasing
 --source-map                   Enables building input's source map
 --source-map-inline-sources    Enables inlining sources inside source maps
+--input-source-map [file]      Specifies the path of the input source map file
 ```
 
 ## Compatibility modes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clean-css-cli",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "A command-line interface to clean-css CSS optimization library",
   "scripts": {
     "check": "jshint ./bin/cleancss .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clean-css-cli",
-  "version": "4.3.0",
+  "version": "4.3.0-pre",
   "description": "A command-line interface to clean-css CSS optimization library",
   "scripts": {
     "check": "jshint ./bin/cleancss .",

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -694,4 +694,49 @@ vows.describe('cleancss')
       }
     }
   })
+  .addBatch({
+    'process an input-source-map': pipedContext(fs.readFileSync('./test/fixtures/source-maps/map/styles.css'), '-o ./test/styles.min.css --input-source-map ./test/fixtures/source-maps/map/input.map', {
+      'enables the source map flag': function() {
+        assert.isTrue(fs.existsSync('test/styles.min.css'));
+        assert.isTrue(fs.existsSync('test/styles.min.css.map'));
+      },
+      'teardown': function () {
+        deleteFile('test/styles.min.css');
+        deleteFile('test/styles.min.css.map');
+      }
+    })
+  })
+  .addBatch({
+    'missing an input-source-map': pipedContext(fs.readFileSync('./test/fixtures/source-maps/map/styles.css'), '-o ./test/styles.min.css', {
+      'does not generate a source map if the parameter is missing': function() {
+        assert.isTrue(fs.existsSync('test/styles.min.css'));
+        assert.isFalse(fs.existsSync('test/styles.min.css.map'));
+      },
+      'teardown': function () {
+        deleteFile('test/styles.min.css');
+      }
+    })
+  })
+  .addBatch({
+    'content of input-source-map': pipedContext(fs.readFileSync('./test/fixtures/source-maps/map/styles.css'), '-o ./test/styles.min.css --input-source-map ./test/fixtures/source-maps/map/input.map', {
+      'includes the right content of the source map': function() {
+        assert.isTrue(fs.existsSync('test/styles.min.css.map'));
+        var sourceMap = new SourceMapConsumer(fs.readFileSync('./test/styles.min.css.map', 'utf-8'));
+
+        assert.deepEqual(
+          sourceMap.originalPositionFor({ line: 1, column: 1 }),
+          {
+            source: 'styles.less',
+            line: 1,
+            column: 4,
+            name: null
+          }
+        );
+      },
+      'teardown': function () {
+        deleteFile('test/styles.min.css');
+        deleteFile('test/styles.min.css.map');
+      }
+    })
+  })
   .export(module);

--- a/test/fixtures/source-maps/map/input.map
+++ b/test/fixtures/source-maps/map/input.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["styles.less"],"names":[],"mappings":"AAAA,GAAI;EACF,WAAA","file":"styles.css"}

--- a/test/fixtures/source-maps/map/styles.css
+++ b/test/fixtures/source-maps/map/styles.css
@@ -1,0 +1,3 @@
+div > a {
+  color: blue;
+}


### PR DESCRIPTION
Addresses https://github.com/jakubpawlowicz/clean-css-cli/issues/27