### PR TITLE
Add CodeQL action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - master
+      - "!dependabot/**"
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches:
+      - master
+  schedule:
+    - cron: "0 2 * * 5"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: "javascript"
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
This is the successor of lgtm.com baked by GitHub.

I plan to add CodeQL in clean-css too, because there are certainly some issues that the current jshint config does not catch like prototype pollution issues...

But because I don't have a lot of time, and linting is something that we might not agree on, let's land CodeQL which should catch potential security issues. :)