### PR TITLE
Update readme to replace `--level` option with `-O`

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,10 +238,10 @@ cleancss --inline 'local,remote,!fonts.googleapis.com' one.css
 
 ## Optimization levels
 
-The `--level` option can be either `0`, `1` (default), or `2`, e.g.
+The `-O` option can be either `0`, `1` (default), or `2`, e.g.
 
 ```shell
-cleancss --level 2 one.css
+cleancss -O2 one.css
 ```
 
 or a fine-grained configuration given via a string.


### PR DESCRIPTION
This change removes mention of the `--level` option which never existed. In versions earlier than 5.0.0, clean-css-cli used to accept the invalid option silently.  With versions > 5.0.0, trying to use the option results in the following: `error: unknown option '--level'`.  The root cause of the change the upgrade to [commander v7.0.0](https://github.com/tj/commander.js/pull/1409), where unknown (excess) command arguments are now raised as an error.

For interest, I was using the option because Bootstrap [previously used it](https://github.com/twbs/bootstrap/pull/32097) in their package.json.